### PR TITLE
fix: move release script to .github/scripts/ to prevent it from being…

### DIFF
--- a/.github/scripts/release.js
+++ b/.github/scripts/release.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const { execSync } = require('child_process');
+const path = require('path');
+
+// Get version type from command line argument
+const versionType = process.argv[2] || 'minor';
+
+if (!['patch', 'minor', 'major'].includes(versionType)) {
+  console.error('Invalid version type. Use: patch, minor, or major');
+  process.exit(1);
+}
+
+// Go up two directories from .github/scripts to root
+const rootDir = path.join(__dirname, '..', '..');
+
+// Read current versions
+const packagePath = path.join(rootDir, 'package.json');
+const modulePath = path.join(rootDir, 'module.json');
+const changelogPath = path.join(rootDir, 'CHANGELOG.md');
+
+const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+const moduleJson = JSON.parse(fs.readFileSync(modulePath, 'utf8'));
+
+// Parse current version
+const currentVersion = packageJson.version;
+const [major, minor, patch] = currentVersion.split('.').map(Number);
+
+// Calculate new version
+let newVersion;
+switch (versionType) {
+  case 'major':
+    newVersion = `${major + 1}.0.0`;
+    break;
+  case 'minor':
+    newVersion = `${major}.${minor + 1}.0`;
+    break;
+  case 'patch':
+    newVersion = `${major}.${minor}.${patch + 1}`;
+    break;
+}
+
+console.log(`Bumping version from ${currentVersion} to ${newVersion}`);
+
+// Update package.json
+packageJson.version = newVersion;
+fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n');
+
+// Update module.json
+moduleJson.version = newVersion;
+// Update download URL to match new version
+moduleJson.download = `https://github.com/jesshmusic/fvtt-challenge-calculator/releases/download/v${newVersion}/module.zip`;
+fs.writeFileSync(modulePath, JSON.stringify(moduleJson, null, 2) + '\n');
+
+// Generate changelog
+function getGitLog(fromTag) {
+  try {
+    const command = fromTag
+      ? `git log ${fromTag}..HEAD --pretty=format:"%s" --no-merges`
+      : `git log --pretty=format:"%s" --no-merges -20`;
+    return execSync(command, { encoding: 'utf8', cwd: rootDir })
+      .split('\n')
+      .filter(line => line.trim());
+  } catch (error) {
+    console.warn('Could not get git log:', error.message);
+    return [];
+  }
+}
+
+function getLastTag() {
+  try {
+    return execSync('git describe --tags --abbrev=0', { encoding: 'utf8', cwd: rootDir }).trim();
+  } catch (error) {
+    return null;
+  }
+}
+
+function categorizeCommits(commits) {
+  const categories = {
+    features: [],
+    fixes: [],
+    changes: [],
+    other: []
+  };
+
+  commits.forEach(commit => {
+    const lower = commit.toLowerCase();
+    if (lower.startsWith('feat:') || lower.startsWith('feature:') || lower.includes('add ')) {
+      categories.features.push(commit.replace(/^(feat|feature):\s*/i, ''));
+    } else if (lower.startsWith('fix:') || lower.includes('fix ')) {
+      categories.fixes.push(commit.replace(/^fix:\s*/i, ''));
+    } else if (lower.startsWith('chore:') || lower.startsWith('refactor:') || lower.startsWith('update:')) {
+      categories.changes.push(commit.replace(/^(chore|refactor|update):\s*/i, ''));
+    } else if (!lower.startsWith('build:') && !lower.startsWith('ci:')) {
+      categories.other.push(commit);
+    }
+  });
+
+  return categories;
+}
+
+// Get commits since last tag
+const lastTag = getLastTag();
+const commits = getGitLog(lastTag);
+const categories = categorizeCommits(commits);
+
+// Read existing changelog or create new one
+let changelog = '';
+if (fs.existsSync(changelogPath)) {
+  changelog = fs.readFileSync(changelogPath, 'utf8');
+}
+
+// Generate new changelog entry
+const date = new Date().toISOString().split('T')[0];
+let newEntry = `## [${newVersion}] - ${date}\n\n`;
+
+if (categories.features.length > 0) {
+  newEntry += `### Added\n`;
+  categories.features.forEach(commit => {
+    newEntry += `- ${commit}\n`;
+  });
+  newEntry += '\n';
+}
+
+if (categories.fixes.length > 0) {
+  newEntry += `### Fixed\n`;
+  categories.fixes.forEach(commit => {
+    newEntry += `- ${commit}\n`;
+  });
+  newEntry += '\n';
+}
+
+if (categories.changes.length > 0) {
+  newEntry += `### Changed\n`;
+  categories.changes.forEach(commit => {
+    newEntry += `- ${commit}\n`;
+  });
+  newEntry += '\n';
+}
+
+if (categories.other.length > 0) {
+  newEntry += `### Other\n`;
+  categories.other.forEach(commit => {
+    newEntry += `- ${commit}\n`;
+  });
+  newEntry += '\n';
+}
+
+// Insert new entry at the top of changelog
+if (!changelog.startsWith('# Changelog')) {
+  changelog = '# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n' + changelog;
+}
+
+const lines = changelog.split('\n');
+const headerEndIndex = lines.findIndex((line, i) => i > 0 && line.startsWith('## '));
+if (headerEndIndex > 0) {
+  lines.splice(headerEndIndex, 0, newEntry);
+} else {
+  lines.push('\n' + newEntry);
+}
+
+changelog = lines.join('\n');
+fs.writeFileSync(changelogPath, changelog);
+
+console.log('✓ Updated package.json');
+console.log('✓ Updated module.json');
+console.log('✓ Updated CHANGELOG.md');
+console.log(`\nNew version: ${newVersion}`);

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,5 +140,5 @@ jobs:
           timeout: 60000
           url: "https://api.foundryvtt.com/_api/packages/release_version/"
           method: "POST"
-          customHeaders: '{"Content-Type": "application/json", "Authorization":"${{secrets.FOUNDRY_PACKAGE_RELEASE_TOKEN}}"}'
+          customHeaders: '{"Content-Type": "application/json", "Authorization":"${{secrets.FOUNDRY_PACKAGE_TOKEN}}"}'
           data: '{"id": "fvtt-challenge-calculator", "release": { "version": "${{github.event.release.tag_name}}", "manifest": "https://github.com/jesshmusic/fvtt-challenge-calculator/releases/download/${{github.event.release.tag_name}}/module.json", "notes": "https://github.com/jesshmusic/fvtt-challenge-calculator", "compatibility": {"minimum": "13","verified": "13"}}}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Dorman Lakely's 5e CR Calculator will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2025-10-30
+
+### Added
+- add auto-release workflow and release scripts for master branch
+- add manual release workflow
+- chore: update startup logs to match consistent format with colored version/build numbers, add auto-increment build system
+
+### Changed
+- bump version to 2.0.1
+
+
 ## [2.0.1] - 2025-10-30
 
 ### Added

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "fvtt-challenge-calculator",
   "title": "Dorman Lakely's 5e CR Calculator",
   "description": "Calculate accurate Challenge Ratings for D&D 5e NPCs based on DMG guidelines. Analyzes HP, AC, damage output, and special abilities to determine CR automatically.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "compatibility": {
     "minimum": "13",
     "verified": "13"
@@ -29,7 +29,7 @@
   ],
   "url": "https://github.com/jesshmusic/fvtt-challenge-calculator",
   "manifest": "#{MANIFEST}#",
-  "download": "https://github.com/jesshmusic/fvtt-challenge-calculator/releases/download/v2.0.1/module.zip",
+  "download": "https://github.com/jesshmusic/fvtt-challenge-calculator/releases/download/v2.1.0/module.zip",
   "license": "LICENSE",
   "readme": "README.md",
   "media": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fvtt-challenge-calculator",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Dorman Lakely's 5e CR Calculator for FoundryVTT",
   "main": "scripts/main.js",
   "scripts": {
@@ -11,9 +11,9 @@
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\" \"**/*.json\" \"**/*.md\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"**/*.json\" \"**/*.md\"",
-    "release:patch": "node scripts/release.js patch",
-    "release:minor": "node scripts/release.js minor",
-    "release:major": "node scripts/release.js major"
+    "release:patch": "node .github/scripts/release.js patch",
+    "release:minor": "node .github/scripts/release.js minor",
+    "release:major": "node .github/scripts/release.js major"
   },
   "repository": "https://github.com/jesshmusic/fvtt-challenge-calculator.git",
   "author": "Jess Hendricks",

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -766,7 +766,7 @@ class CRCalculatorDialog extends HandlebarsApplicationMixin(ApplicationV2) {
     this.close();
   }
 }
-const version = "2.0.1";
+const version = "2.1.0";
 const packageInfo = {
   version
 };


### PR DESCRIPTION
… cleaned

- Move release.js from scripts/ to .github/scripts/ directory
- Update package.json to reference new location
- scripts/ is Vite build output and gets cleaned, causing script to disappear
- Bump version to 2.1.0 as part of testing fixed release script

🤖 Generated with [Claude Code](https://claude.com/claude-code)